### PR TITLE
nix: remove xorg deprecation warning

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@
   wayland,
   wayland-protocols,
   wayland-scanner,
-  xorg,
+  libxcb,
   libdrm,
   libgbm ? null,
   vulkan-headers,
@@ -79,7 +79,7 @@
     ++ lib.optional (withWayland && lib.strings.compareVersions qt6.qtbase.version "6.10.0" == -1) qt6.qtwayland
     ++ lib.optionals withWayland [ wayland wayland-protocols ]
     ++ lib.optionals (withWayland && libgbm != null) [ libdrm libgbm vulkan-headers ]
-    ++ lib.optional withX11 xorg.libxcb
+    ++ lib.optional withX11 libxcb
     ++ lib.optional withPam pam
     ++ lib.optional withPipewire pipewire
     ++ lib.optionals withPolkit [ polkit glib ];


### PR DESCRIPTION
Removes the

> evaluation warning: The xorg package set has been deprecated, 'xorg.libxcb' has been renamed to 'libxcb'

when evaluating the package.

See: https://github.com/quickshell-mirror/quickshell/pull/552 for the same PR upstream