### PR TITLE
fix(io/jsonadapter): fix inverted `isNew` branches in `list<JsonObject>` deserialization

### DIFF
--- a/src/io/jsonadapter.cpp
+++ b/src/io/jsonadapter.cpp
@@ -211,15 +211,15 @@ void JsonAdapter::deserializeRec(const QJsonObject& json, QObject* obj, const QM
 						const auto& jsonValue = array.at(i);
 						if (jsonValue.isObject()) {
 							if (isNew) {
-								currentValue = lp.at(&lp, i);
-								if (this->oldCreatedObjects.removeOne(currentValue)) {
-									this->createdObjects.push_back(currentValue);
-								}
-							} else {
 								// FIXME: should be the type inside the QQmlListProperty but how can we get that?
 								currentValue = static_cast<JsonObject*>(QMetaType::fromType<JsonObject>().create());
 								currentValue->setParent(this);
 								this->createdObjects.push_back(currentValue);
+							} else {
+								currentValue = lp.at(&lp, i);
+								if (this->oldCreatedObjects.removeOne(currentValue)) {
+									this->createdObjects.push_back(currentValue);
+								}
 							}
 
 							this->deserializeRec(


### PR DESCRIPTION
## What

In `JsonAdapter::deserializeRec()`, the two branches handling new vs. existing
slots in a `list<JsonObject>` property are swapped.

`isNew` is `true` when `i >= lpCount`, meaning the JSON array is longer than the
existing list and no slot exists at index `i` yet. Despite this, the original code:

- **`isNew == true`** → calls `lp.at(&lp, i)` — an **out-of-bounds read** on the existing list
- **`isNew == false`** → allocates a brand new `JsonObject` — **ignoring and leaking the existing slot**

The fix swaps the two branches so that:

- **`isNew == true`** → allocate a new `JsonObject`, track it in `createdObjects`, append it to the list
- **`isNew == false`** → read the existing slot via `lp.at()`, migrate it from `oldCreatedObjects` if applicable

## Impact

Any `JsonAdapter` subclass with a `property list<SomeJsonObject>` typed property
is affected. Concretely:

- On the very first load, `lpCount` is 0, so `isNew` is always `true` and `lp.at()`
  is always called out-of-bounds — the feature is effectively **broken for all
  non-empty `list<JsonObject>` properties**, not only on reload.
- On subsequent deserializations where the JSON array grows, the same out-of-bounds
  read occurs for any new entries.
- When the JSON array is equal to or shorter than the current list, existing objects
  are silently discarded and replaced with freshly allocated ones, losing any state
  and leaking the old objects until the next `deserializeAdapter` call cleans up
  `oldCreatedObjects`.

`list<string>`, `list<int>`, `var`, and plain `JsonObject` (non-list) properties
are not affected.