### PR TITLE
fix(core/scriptmodel): use `qScopeGuard` to reset `hasActiveIterators`

### DIFF
--- a/src/core/scriptmodel.cpp
+++ b/src/core/scriptmodel.cpp
@@ -6,6 +6,7 @@
 #include <qcontainerfwd.h>
 #include <qlist.h>
 #include <qnamespace.h>
+#include <qscopeguard.h>
 #include <qtmetamacros.h>
 #include <qtversionchecks.h>
 #include <qtypes.h>
@@ -13,6 +14,7 @@
 
 void ScriptModel::updateValuesUnique(const QVariantList& newValues) {
 	this->hasActiveIterators = true;
+	auto guard = qScopeGuard([this] { this->hasActiveIterators = false; });
 	this->mValues.reserve(newValues.size());
 
 	auto iter = this->mValues.begin();
@@ -153,7 +155,6 @@ void ScriptModel::updateValuesUnique(const QVariantList& newValues) {
 		}
 	}
 
-	this->hasActiveIterators = false;
 }
 
 void ScriptModel::setValues(const QVariantList& newValues) {


### PR DESCRIPTION
## What

`updateValuesUnique()` sets `hasActiveIterators = true` at the top and manually resets it to `false` at the bottom. If any of the `beginRemoveRows`, `endRemoveRows`, `beginInsertRows`, `endInsertRows`, or `beginMoveRows` / `endMoveRows` calls trigger a connected slot that throws or otherwise unwinds the stack early, the flag is never cleared and `ScriptModel` becomes permanently broken: the `values()` getter will always detach the backing list, and any further call to `setValues()` or `setObjectProp()` re-enters with stale state.

Replace the manual reset with a `qScopeGuard`, which is already used elsewhere in the codebase (`core/desktopentry.cpp`, `services/pipewire/peak.cpp`, `wayland/idle_notify/monitor.cpp`) and guarantees the flag is cleared regardless of how the function exits.