### PR TITLE
clean up GCC build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,10 @@ boption(NETWORK "Network" ON)
 include(cmake/install-qml-module.cmake)
 include(cmake/util.cmake)
 
-add_compile_options(-Wall -Wextra -Wno-vla-cxx-extension)
+add_compile_options(-Wall -Wextra)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+	add_compile_options(-Wno-vla-cxx-extension)
+endif()
 
 # pipewire defines this, breaking PCH
 add_compile_definitions(_REENTRANT)

--- a/cmake/pch.cmake
+++ b/cmake/pch.cmake
@@ -31,13 +31,17 @@ function (qs_add_pchset SETNAME)
 		return()
 	endif()
 
-	cmake_parse_arguments(PARSE_ARGV 1 arg "" "" "HEADERS;DEPENDENCIES")
+	cmake_parse_arguments(PARSE_ARGV 1 arg "" "" "HEADERS;DEPENDENCIES;COMPILE_DEFINITIONS")
 
 	set(LIBNAME "qs-pchset-${SETNAME}")
 
 	add_library(${LIBNAME} ${CMAKE_BINARY_DIR}/pchstub.cpp)
 	target_link_libraries(${LIBNAME} ${arg_DEPENDENCIES})
 	target_precompile_headers(${LIBNAME} PUBLIC ${arg_HEADERS})
+
+	if (arg_COMPILE_DEFINITIONS)
+		target_compile_definitions(${LIBNAME} PUBLIC ${arg_COMPILE_DEFINITIONS})
+	endif()
 endfunction()
 
 set(COMMON_PCH_SET
@@ -56,6 +60,7 @@ set(COMMON_PCH_SET
 qs_add_pchset(common
 	DEPENDENCIES Qt::Quick
 	HEADERS ${COMMON_PCH_SET}
+	COMPILE_DEFINITIONS _REENTRANT
 )
 
 qs_add_pchset(large
@@ -72,6 +77,7 @@ qs_add_pchset(large
 		<qdir.h>
 		<qtimer.h>
 		<qabstractitemmodel.h>
+	COMPILE_DEFINITIONS _REENTRANT
 )
 
 

--- a/src/launch/main.cpp
+++ b/src/launch/main.cpp
@@ -25,7 +25,10 @@ namespace qs::launch {
 namespace {
 
 void checkCrashRelaunch(char** argv, QCoreApplication* coreApplication) {
-#if CRASH_REPORTER
+#if !CRASH_REPORTER
+	(void)argv;
+	(void)coreApplication;
+#else
 	auto lastInfoFdStr = qEnvironmentVariable("__QUICKSHELL_CRASH_INFO_FD");
 
 	if (!lastInfoFdStr.isEmpty()) {

--- a/src/network/nm/backend.cpp
+++ b/src/network/nm/backend.cpp
@@ -157,6 +157,7 @@ void NetworkManager::registerFrontendDevice(NMDeviceType::Enum type, NMDevice* d
 			case NM80211Mode::Ap: return WifiDeviceMode::AccessPoint;
 			case NM80211Mode::Mesh: return WifiDeviceMode::Mesh;
 			}
+			Q_UNREACHABLE();
 		};
 		// clang-format off
 		frontendWifiDev->bindableMode().setBinding(translateMode);
@@ -179,6 +180,7 @@ void NetworkManager::registerFrontendDevice(NMDeviceType::Enum type, NMDevice* d
 		case 100: return DeviceConnectionState::Connected;
 		case 110 ... 120: return DeviceConnectionState::Disconnecting;
 		}
+		Q_UNREACHABLE();
 	};
 	// clang-format off
 	frontendDev->bindableName().setBinding([dev]() { return dev->interface(); });

--- a/src/network/nm/utils.cpp
+++ b/src/network/nm/utils.cpp
@@ -111,6 +111,7 @@ bool securityIsValid(
 		break;
 	case WifiSecurityType::Leap:
 		if (adhoc) return false;
+		[[fallthrough]];
 	case WifiSecurityType::StaticWep:
 		if (!(apFlags & NM80211ApFlags::Privacy)) return false;
 		if (apWpa || apRsn) {

--- a/src/services/pipewire/peak.cpp
+++ b/src/services/pipewire/peak.cpp
@@ -32,7 +32,11 @@
 #include "qml.hpp"
 
 #pragma GCC diagnostic push
+#ifdef __clang__
 #pragma GCC diagnostic ignored "-Wmissing-designated-field-initializers"
+#else
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
 
 namespace qs::service::pipewire {
 

--- a/src/services/upower/powerprofiles.cpp
+++ b/src/services/upower/powerprofiles.cpp
@@ -169,7 +169,7 @@ QString DBusDataTransform<PowerProfile::Enum>::toWire(Data data) {
 	case PowerProfile::PowerSaver: return QStringLiteral("power-saver");
 	case PowerProfile::Balanced: return QStringLiteral("balanced");
 	case PowerProfile::Performance: return QStringLiteral("performance");
-	default: qFatal() << "Attempted to convert invalid power profile" << data << "to wire format.";
+	default: qFatal() << "Attempted to convert invalid power profile" << data << "to wire format."; Q_UNREACHABLE();
 	}
 }
 


### PR DESCRIPTION
Fixes several warnings that appear when building with GCC, and resolves a
Clang PCH build failure when polkit is enabled.

## `CMakeLists.txt` - guard `-Wno-vla-cxx-extension` for Clang only

This flag is Clang-specific. GCC does not recognise it and emits a warning
on every translation unit. It is now conditionally applied only when the compiler is Clang.

## `cmake/pch.cmake` - fix PCH/pthread mismatch with Clang

`_REENTRANT` was added as a global compile definition (to work around PipeWire
headers) but was not propagated to the `qs-pchset-*` library targets that own
the precompiled headers. With Clang, this caused every translation unit in the
`polkit` module to fail with:

```
error: POSIX thread support was disabled in precompiled file
'...cmake_pch.hxx.gch'
but is currently enabled
```

`qs_add_pchset` now accepts a `COMPILE_DEFINITIONS` argument, and `_REENTRANT`
is passed to the `common` and `large` PCH sets so the PCH and its consumers
agree on the threading model.

## `src/services/pipewire/peak.cpp` - fix pragma for GCC

`-Wmissing-designated-field-initializers` is a Clang-specific diagnostic name.
GCC uses `-Wmissing-field-initializers` for the same warning. The `#pragma GCC
diagnostic` block now selects the correct name based on the compiler.

## `src/launch/main.cpp` - suppress unused parameter warnings with `-DCRASH_REPORTER=OFF`

Both parameters of `checkCrashRelaunch` are only used inside the `#if CRASH_REPORTER` block. When crash reporting is disabled the compiler
correctly warns about unused parameters. Added `(void)` casts in the `!CRASH_REPORTER` path.

## `src/network/nm/backend.cpp` - add `Q_UNREACHABLE()` after exhaustive switches

Two lambdas (`translateMode`, `translateState`) have switches that cover all
defined enum/range values but have no default case and no trailing return.
GCC warns about control reaching the end of a non-void function. Added `Q_UNREACHABLE()` after each switch to make the intent explicit and silence
the warning.

## `src/services/upower/powerprofiles.cpp` - same as above

`toWire()` ends with a `default: qFatal(...)` case. GCC does not infer that
`qFatal()` is `[[noreturn]]` through the `QDebug` operator chain and warns
about a missing return. Added `Q_UNREACHABLE()` after the `qFatal()` call.

## `src/network/nm/utils.cpp` - add `[[fallthrough]]` annotation

The intentional fallthrough from `WifiSecurityType::Leap` into `WifiSecurityType::StaticWep` was missing a `[[fallthrough]]` annotation,
causing a `-Wimplicit-fallthrough` warning.