### PR TITLE
chore(nix): add nix-treefmt (with nixfmt, deadnix & statix)

### DIFF
--- a/ci/matrix.nix
+++ b/ci/matrix.nix
@@ -1,11 +1,16 @@
 {
   qtver,
   compiler,
-}: let
+}:
+let
   checkouts = import ./nix-checkouts.nix;
-  nixpkgs = checkouts.${builtins.replaceStrings ["."] ["_"] qtver};
-  compilerOverride = (nixpkgs.callPackage ./variations.nix {}).${compiler};
-  pkg = (nixpkgs.callPackage ../default.nix {}).override (compilerOverride // {
-    wayland-protocols = checkouts.latest.wayland-protocols;
-  });
-in pkg
+  nixpkgs = checkouts.${builtins.replaceStrings [ "." ] [ "_" ] qtver};
+  compilerOverride = (nixpkgs.callPackage ./variations.nix { }).${compiler};
+  pkg = (nixpkgs.callPackage ../default.nix { }).override (
+    compilerOverride
+    // {
+      inherit (checkouts.latest) wayland-protocols;
+    }
+  );
+in
+pkg

--- a/ci/nix-checkouts.nix
+++ b/ci/nix-checkouts.nix
@@ -1,13 +1,16 @@
 let
-  byCommit = {
-    commit,
-    sha256,
-  }: import (builtins.fetchTarball {
-    name = "nixpkgs-${commit}";
-    url = "https://github.com/nixos/nixpkgs/archive/${commit}.tar.gz";
-    inherit sha256;
-  }) {};
-in rec {
+  byCommit =
+    {
+      commit,
+      sha256,
+    }:
+    import (builtins.fetchTarball {
+      name = "nixpkgs-${commit}";
+      url = "https://github.com/nixos/nixpkgs/archive/${commit}.tar.gz";
+      inherit sha256;
+    }) { };
+in
+rec {
   latest = qt6_10_0;
 
   qt6_10_1 = byCommit {

--- a/ci/variations.nix
+++ b/ci/variations.nix
@@ -1,7 +1,12 @@
 {
   clangStdenv,
   gccStdenv,
-}: {
-  clang = { stdenv = clangStdenv; };
-  gcc = { stdenv = gccStdenv; };
+}:
+{
+  clang = {
+    stdenv = clangStdenv;
+  };
+  gcc = {
+    stdenv = gccStdenv;
+  };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -16,10 +16,27 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1770107345,
+        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "systems": "systems"
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "systems": {
@@ -34,6 +51,24 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default-linux",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1772660329,
+        "narHash": "sha256-IjU1FxYqm+VDe5qIOxoW+pISBlGvVApRjiw/Y/ttJzY=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "3710e0e1218041bbad640352a0440114b1e10428",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -4,44 +4,52 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     systems.url = "github:nix-systems/default-linux";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    systems,
-    ...
-  }: let
-    eachSystem = fn:
-      nixpkgs.lib.genAttrs
-      (import systems)
-      (system: fn nixpkgs.legacyPackages.${system});
+  outputs =
+    {
+      self,
+      nixpkgs,
+      systems,
+      treefmt-nix,
+      ...
+    }:
+    let
+      eachSystem =
+        fn: nixpkgs.lib.genAttrs (import systems) (system: fn nixpkgs.legacyPackages.${system});
 
-    mkDate = longDate:
-      nixpkgs.lib.concatStringsSep "-" [
-        (builtins.substring 0 4 longDate)
-        (builtins.substring 4 2 longDate)
-        (builtins.substring 6 2 longDate)
-      ];
+      treefmtEval = eachSystem (pkgs: treefmt-nix.lib.evalModule pkgs ./nix/treefmt.nix);
 
-    version = mkDate (self.lastModifiedDate or "19700101") + "_" + (self.shortRev or "dirty");
-    gitRev = self.rev or self.dirtyRev or "dirty";
-  in {
-    overlays.default = final: prev: {
-      quickshell = final.callPackage ./nix/package.nix {inherit version gitRev;};
-    };
+      mkDate =
+        longDate:
+        nixpkgs.lib.concatStringsSep "-" [
+          (builtins.substring 0 4 longDate)
+          (builtins.substring 4 2 longDate)
+          (builtins.substring 6 2 longDate)
+        ];
 
-    packages = eachSystem (pkgs: {
-      quickshell = pkgs.callPackage ./nix/package.nix {inherit version gitRev;};
-      default = self.packages.${pkgs.stdenv.hostPlatform.system}.quickshell;
-    });
-
-    devShells = eachSystem (pkgs: {
-      default = pkgs.callPackage ./nix/shell.nix {
-        quickshell = self.packages.${pkgs.stdenv.hostPlatform.system}.quickshell.override {
-          stdenv = pkgs.clangStdenv;
-        };
+      version = mkDate (self.lastModifiedDate or "19700101") + "_" + (self.shortRev or "dirty");
+      gitRev = self.rev or self.dirtyRev or "dirty";
+    in
+    {
+      overlays.default = final: _prev: {
+        quickshell = final.callPackage ./nix/package.nix { inherit version gitRev; };
       };
-    });
-  };
+
+      packages = eachSystem (pkgs: {
+        quickshell = pkgs.callPackage ./nix/package.nix { inherit version gitRev; };
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.quickshell;
+      });
+
+      devShells = eachSystem (pkgs: {
+        default = pkgs.callPackage ./nix/shell.nix {
+          quickshell = self.packages.${pkgs.stdenv.hostPlatform.system}.quickshell.override {
+            stdenv = pkgs.clangStdenv;
+          };
+        };
+      });
+
+      formatter = eachSystem (pkgs: treefmtEval.${pkgs.system}.config.build.wrapper);
+    };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -8,41 +8,42 @@
   makeWrapper,
   openssl,
   quickshell,
-}: let
+}:
+let
   tidyfox = import (pkgs.fetchFromGitea {
     domain = "git.outfoxxed.me";
     owner = "outfoxxed";
     repo = "tidyfox";
     rev = "9d85d7e7dea2602aa74ec3168955fee69967e92f";
     hash = "sha256-77ERiweF6lumonp2c/124rAoVG6/o9J+Aajhttwtu0w=";
-  }) {inherit pkgs;};
+  }) { inherit pkgs; };
 in
-  mkShell.override {stdenv = clangStdenv;} {
-    inputsFrom = [quickshell];
+mkShell.override { stdenv = clangStdenv; } {
+  inputsFrom = [ quickshell ];
 
-    packages = [
-      just
-      clang-tools
-      parallel
-      makeWrapper
-      openssl
-    ];
+  packages = [
+    just
+    clang-tools
+    parallel
+    makeWrapper
+    openssl
+  ];
 
-    TIDYFOX = "${tidyfox}/lib/libtidyfox.so";
+  TIDYFOX = "${tidyfox}/lib/libtidyfox.so";
 
-    shellHook = ''
-      export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+  shellHook = ''
+    export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
 
-      # Qt environment setup
-      # https://discourse.nixos.org/t/qt-development-environment-on-a-flake-system/23707/5
-      setQtEnvironment=$(mktemp)
-      random=$(openssl rand -base64 20 | sed "s/[^a-zA-Z0-9]//g")
-      makeShellWrapper "$(type -p sh)" "$setQtEnvironment" "''${qtWrapperArgs[@]}" --argv0 "$random"
-      sed "/$random/d" -i "$setQtEnvironment"
-      source "$setQtEnvironment"
+    # Qt environment setup
+    # https://discourse.nixos.org/t/qt-development-environment-on-a-flake-system/23707/5
+    setQtEnvironment=$(mktemp)
+    random=$(openssl rand -base64 20 | sed "s/[^a-zA-Z0-9]//g")
+    makeShellWrapper "$(type -p sh)" "$setQtEnvironment" "''${qtWrapperArgs[@]}" --argv0 "$random"
+    sed "/$random/d" -i "$setQtEnvironment"
+    source "$setQtEnvironment"
 
-      # qmlls does not account for the import path and bases its search off qtbase's path.
-      # The actual imports come from qtdeclarative. This directs qmlls to the correct imports.
-      export QMLLS_BUILD_DIRS=$(pwd)/build:$QML2_IMPORT_PATH
-    '';
-  }
+    # qmlls does not account for the import path and bases its search off qtbase's path.
+    # The actual imports come from qtdeclarative. This directs qmlls to the correct imports.
+    export QMLLS_BUILD_DIRS=$(pwd)/build:$QML2_IMPORT_PATH
+  '';
+}

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -1,0 +1,8 @@
+{
+  projectRootFile = "flake.nix";
+
+  # nix
+  programs.nixfmt.enable = true; # formatter
+  programs.deadnix.enable = true; # linter
+  programs.statix.enable = true; # linter
+}


### PR DESCRIPTION
same linters/formatter noctalia-shell uses for nix related things. nix-treefmt is just for convenience so you don’t have to run them manually for each file.