### PR TITLE
fix(pipewire): use QPointer to prevent use-after-free on node removal

### DIFF
--- a/src/services/pipewire/peak.hpp
+++ b/src/services/pipewire/peak.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <qobject.h>
+#include <qpointer.h>
 #include <qqmlintegration.h>
 #include <qtclasshelpermacros.h>
 #include <qtmetamacros.h>
@@ -75,7 +76,7 @@ private:
 	void clearPeaks();
 	void rebuildStream();
 
-	PwNodeIface* mNode = nullptr;
+	QPointer<PwNodeIface> mNode;
 	PwBindableRef<PwNode> mNodeRef;
 	bool mEnabled = true;
 	QVector<float> mPeaks;

--- a/src/services/pipewire/qml.hpp
+++ b/src/services/pipewire/qml.hpp
@@ -2,6 +2,7 @@
 
 #include <qcontainerfwd.h>
 #include <qobject.h>
+#include <qpointer.h>
 #include <qqmlintegration.h>
 #include <qqmllist.h>
 #include <qtclasshelpermacros.h>
@@ -209,7 +210,7 @@ private:
 
 	void updateLinks();
 
-	PwNodeIface* mNode = nullptr;
+	QPointer<PwNodeIface> mNode;
 	QVector<PwLinkGroupIface*> mLinkGroups;
 };
 

--- a/src/services/pipewire/spectrum.hpp
+++ b/src/services/pipewire/spectrum.hpp
@@ -5,6 +5,7 @@
 
 #include <qlist.h>
 #include <qobject.h>
+#include <qpointer.h>
 #include <qqmlintegration.h>
 #include <qtclasshelpermacros.h>
 #include <qtmetamacros.h>
@@ -120,7 +121,7 @@ private:
 	void computeBandBins();
 
 	// QML state
-	PwNodeIface* mNode = nullptr;
+	QPointer<PwNodeIface> mNode;
 	PwBindableRef<PwNode> mNodeRef;
 	bool mEnabled = false;
 	int mBandCount = 32;


### PR DESCRIPTION
## Summary

- Fixes a SIGSEGV crash when disconnecting Bluetooth audio devices (e.g. AirPods)
- The crash occurs because `PwNodeIface` is deleted synchronously via the `destroying` signal, but `PwAudioSpectrum`, `PwNodeLinkTracker`, and `PwNodePeakMonitor` may still hold a dangling `mNode` pointer when a deferred QML binding re-evaluation calls `setNode()`, which tries to `QObject::disconnect()` from the dead object
- Replaces raw `PwNodeIface*` with `QPointer<PwNodeIface>` so the pointer auto-nulls on destruction and existing null guards correctly skip the disconnect

## Crash backtrace

```
Signal: 11 (SEGV)
#0  QObject::disconnect (libQt6Core.so.6 + 0x1ee737)
#1  n/a (/usr/bin/quickshell + 0x2ddc75)
#2  n/a (/usr/bin/quickshell + 0x2c7f0c)
#3  QObject::event (libQt6Core.so.6 + 0x1eb801)
#4  QCoreApplication::notifyInternal2 (libQt6Core.so.6 + 0x186628)
#5  QCoreApplicationPrivate::sendPostedEvents (libQt6Core.so.6 + 0x1869c8)
```

Reproduced on noctalia-qs 0.0.12-1 / noctalia-shell 4.7.5-1 / CachyOS / niri.

## Test plan

- [x] Built and ran patched binary
- [x] Connected AirPods, then disconnected — noctalia survived without crashing
- [x] Previously crashed 100% of the time on disconnect (two identical coredumps on separate days)