### PR TITLE
fix(pipewire): avoid crash on device disconnect in default tracker

### DIFF
--- a/src/services/pipewire/defaults.hpp
+++ b/src/services/pipewire/defaults.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <qobject.h>
+#include <qpointer.h>
 #include <qtmetamacros.h>
 
 #include "registry.hpp"
@@ -67,16 +68,16 @@ private:
 	PwRegistry* registry;
 	PwBindableRef<PwMetadata> defaultsMetadata;
 
-	PwNode* mDefaultSink = nullptr;
+	QPointer<PwNode> mDefaultSink = nullptr;
 	QString mDefaultSinkName;
 
-	PwNode* mDefaultSource = nullptr;
+	QPointer<PwNode> mDefaultSource = nullptr;
 	QString mDefaultSourceName;
 
-	PwNode* mDefaultConfiguredSink = nullptr;
+	QPointer<PwNode> mDefaultConfiguredSink = nullptr;
 	QString mDefaultConfiguredSinkName;
 
-	PwNode* mDefaultConfiguredSource = nullptr;
+	QPointer<PwNode> mDefaultConfiguredSource = nullptr;
 	QString mDefaultConfiguredSourceName;
 };
 


### PR DESCRIPTION
## Summary
Prevent a SIGSEGV in the PipeWire default tracker when audio devices (especially Bluetooth) disconnect and default sink/source nodes are destroyed.

## What changed
- Switched default node pointers in `PwDefaultTracker` from raw pointers to `QPointer<PwNode>`:
  - `mDefaultSink`
  - `mDefaultSource`
  - `mDefaultConfiguredSink`
  - `mDefaultConfiguredSource`
- Added `#include <qpointer.h>` in `src/services/pipewire/defaults.hpp`.

## Why
On disconnect/hot-unplug paths, node destruction can race with cleanup and lead to `QObject::disconnect(...)` being called with stale pointers, causing a crash.

Using `QPointer` ensures pointers are nulled automatically when the QObject is destroyed, avoiding invalid disconnect access.

## Validation
- Reproduced with Bluetooth headset disconnect:
  - PipeWire warning/error still appears (`Received error event`), but shell no longer crashes.
- Confirmed no new diagnostics in modified files.

## Notes
This change targets crash safety only; it does not suppress PipeWire runtime warnings.