### PR TITLE
fix: add kdePackages.kirigami to buildInputs

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -19,6 +19,7 @@
   pam,
   glib,
   polkit,
+  kdePackages,
   cpptrace,
   libunwind,
   version,
@@ -64,6 +65,7 @@ stdenv.mkDerivation {
     jemalloc
     pam
     pipewire
+    kdePackages.kirigami
     polkit
     glib
     (cpptrace.overrideAttrs (old: {


### PR DESCRIPTION
Motivation:
`qqc2-breeze-style`'s `ScrollView.qml` requires `org.kde.kirigami` at runtime. Without kirigami in `buildInputs` the QML module is not bundled into quickshell's resource path, causing noctalia-shell to fail on load with:

`module "org.kde.kirigami" is not installed`

Type of Change: Bug fix
Testing: Tested on Niri & Hyprland with NixOS unstable. noctalia-shell loads successfully after this change.